### PR TITLE
Fix wrong result caused by null byte character.

### DIFF
--- a/xftwidth.c
+++ b/xftwidth.c
@@ -19,8 +19,8 @@ int main(int argc, char** argv) {
   FcChar8 *str; 
 
   char *name = argv[1];
-  size_t len = strlen(argv[2]) + 1;
- 
+  size_t len = strlen(argv[2]);
+
   str = (FcChar8*) malloc(len * sizeof(FcChar8));
 
   strncpy((char*)str, argv[2], len);


### PR DESCRIPTION
As "len" is the length of the input string plus one strncpy fills the missing character with a null byte. As a result, the string that is used for determining length is too long.

The new version works perfectly fine for me and gives me the right result.
