### PR TITLE
added xftsize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 CC=gcc --std=c11
 CFLAGS=`pkg-config --libs --cflags x11 freetype2 xft fontconfig`
 
+all: xftwidth xftsize
+
 xftwidth: xftwidth.c
 	$(CC) $(CFLAGS) -o $@ $< 
+
+xftsize: xftsize.c
+	$(CC) -g $(CFLAGS) -o $@ $< 

--- a/xftsize.c
+++ b/xftsize.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014- Sebastian Fischmeister
+ * License: http://www.gnu.org/licenses/gpl.html GPL version 3 or higher
+ */
+
+#include <X11/Xft/Xft.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/Xrender.h>
+#include <fontconfig/fontconfig.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char** argv)
+{
+        if (argc < 4)
+        {
+                printf("xftsize font string maxwidth\n");
+                return 1;
+        }
+
+        char *name = argv[1];
+        size_t len = strlen(argv[2]);
+        char *tryname;
+
+        int maxwidth = 0;
+        int trywidth = 10;
+
+        Display *dpy;
+        XftFont *fn;
+        XGlyphInfo ext;
+        FcChar8 str[len]; 
+
+        memcpy(str, argv[2], len);
+        sscanf( argv[3],"%d", &maxwidth);
+        tryname = malloc(strlen(argv[1])+50);
+
+        dpy = XOpenDisplay(NULL);
+        
+        while(ext.width < maxwidth)
+        {
+          	trywidth++;
+          	sprintf(tryname,"%s:size=%d",name,trywidth);
+          
+                fn = XftFontOpenName(dpy, 0, tryname);
+          
+                if (fn == NULL)
+                {
+                	puts("Font not found.");
+                        return 1;
+                }
+          
+                XftTextExtents8(dpy, fn, str, (int)len, &ext);
+        }
+
+        printf("%s\n",tryname);
+        XCloseDisplay(dpy);
+
+        return 0;
+}


### PR DESCRIPTION
I extended your code to solve the following problem: what should be the right font size when wanting to display a string across the whole screen. For this you provide the font specification without the size, the string you want to display, and the maximal width of what you want to show.

This is a crude version (see the malloc) and many possible extensions are possible (e.g., binary search, defined minimum font size, more graceful memory allocation, better error handling). It works for me so far, but it's definitely a hack.

Just give it a try with:

```xftsize "Times New Roman" "This is a message" 1200```